### PR TITLE
Optimizing the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ pip install </path/to/download>
 
 ## Getting started
 ```python
-import spacy
+from spacy import load
 
-nlp = spacy.load("he_ner_news_trf")
+nlp = load("he_ner_news_trf")
 text = """מרגלית דהן
 מספר זהות 11278904-5
 


### PR DESCRIPTION
Significantly shortening the import time
According to timeit, a normal spacy import will take 5.268464000000002 seconds Import of the specific load model, length 3.5131827000000015 seconds only