### PR TITLE
Update ner_head.py

### DIFF
--- a/hebspacy/ner_head.py
+++ b/hebspacy/ner_head.py
@@ -3,6 +3,7 @@ import json
 from collections import defaultdict
 
 import numpy as np
+import cupy as cp
 import torch
 from spacy import Language
 from spacy.tokens import Doc, Span
@@ -39,10 +40,16 @@ class NERHead:
                 item = wp_index % seq_size
 
                 # retrieving the vectors of the token's head word piece from the last 4 layers
-                layer_9 = torch.from_numpy(doc._.trf_data.tensors[2][8][batch][item])
-                layer_10 = torch.from_numpy(doc._.trf_data.tensors[2][9][batch][item])
-                layer_11 = torch.from_numpy(doc._.trf_data.tensors[2][10][batch][item])
-                layer_12 = torch.from_numpy(doc._.trf_data.tensors[2][11][batch][item])
+                if isinstance(doc._.trf_data.tensors[2][8][batch][item], cp.ndarray):
+                    layer_9 = torch.from_numpy(cp.asnumpy(doc._.trf_data.tensors[2][8][batch][item]))
+                    layer_10 = torch.from_numpy(cp.asnumpy(doc._.trf_data.tensors[2][9][batch][item]))
+                    layer_11 = torch.from_numpy(cp.asnumpy(doc._.trf_data.tensors[2][10][batch][item]))
+                    layer_12 = torch.from_numpy(cp.asnumpy(doc._.trf_data.tensors[2][11][batch][item]))
+                else:
+                    layer_9 = torch.from_numpy(doc._.trf_data.tensors[2][8][batch][item])
+                    layer_10 = torch.from_numpy(doc._.trf_data.tensors[2][9][batch][item])
+                    layer_11 = torch.from_numpy(doc._.trf_data.tensors[2][10][batch][item])
+                    layer_12 = torch.from_numpy(doc._.trf_data.tensors[2][11][batch][item])
 
                 # concat the vectors into one
                 concatenated_vector = torch.cat([layer_9, layer_10, layer_11, layer_12])

--- a/hebspacy/version.py
+++ b/hebspacy/version.py
@@ -1,5 +1,5 @@
 _MAJOR = "0"
 _MINOR = "1"
-_REVISION = "7"
+_REVISION = "8"
 
 VERSION = f"{_MAJOR}.{_MINOR}.{_REVISION}"


### PR DESCRIPTION
Update the code, when using spacy.prefer_gpu() before spacy.load() to run the model on GPU we get  cupy.ndarray and than the torch.from_numpy crash in inference.

the commit catch cupy.ndarray and convert it to numpy ndarray and than the program will run as written before.

Resolves #6 
Fix #6 